### PR TITLE
Documentation and shape fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@
 
 This project provides [SHACL](https://www.w3.org/TR/shacl/) to validate metadata against the [eCH-0200 Standard](https://www.ech.ch/vechweb/page?p=dossier&documentNumber=eCH-0200&documentVersion=1.0).
 
-## Status
-
-This project is work in progress. The functionality described in this README might not yet be implemented or not yet work as described.
-
 ## Files
 
  * `ech-0200.shacl.ttl` : This file models the constraints defined in eCH-200 with the SHACL vocabulary

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project provides [SHACL](https://www.w3.org/TR/shacl/) to validate metadata
 
 ## Status
 
-While the basic functionality is usable this project is awaiting more reviewer's feedback as well as discussions in the ECH OGD Group.
+This project is work in progress. The functionality described in this README might not yet be implemented or not yet work as described.
 
 ## Files
 
@@ -24,6 +24,28 @@ For example (from this directory):
     shaclvalidate -shapesfile ech-0200.shacl.ttl -datafile .\examples\minimal.valid.ttl
 
 The example isn't strictly minimal as omitting `dcat:themeTaxonomy` would only resul in a warning.
+
+### Validating not turtle files
+
+In order to work with RDF/XML files you need to convert the file in turtle format.
+
+First you need Jena/riot. To download and extract it type this commands:
+
+```BASH
+wget https://www-eu.apache.org/dist/jena/binaries/apache-jena-3.9.0.tar.gz
+tar xvzf apache-jena-3.9.0.tar.gz
+```
+
+Now you have a folder named `apache-jena-3.9.0`. To convert your `RDF/XML` file (eg. `file.rdf`) you can use this command:
+
+```
+./apache-jena-3.9.0/bin/riot --output=turtle rdfxml file.rdf > file.ttl
+```
+
+And you will find the converted result in `file.ttl`.
+
+riot support these RDF formats: `turtle`, `ntriples`, `nquads`, `trig` and `rdfxml`.
+
 
 ## References
 

--- a/ech-0200.shacl.ttl
+++ b/ech-0200.shacl.ttl
@@ -83,18 +83,24 @@
       sh:minCount 1 ;
       sh:severity sh:Violation ;
     ] ;
-  sh:property [
-      sh:path dct:license ;
-      sh:class dct:LicenseDocument ;
-      sh:maxCount 1 ;
-      sh:severity sh:Violation ;
-    ];
-  sh:property [
-      sh:path dct:rights ;
-      sh:class dct:RightsStatement ;
-      sh:maxCount 1 ;
-      sh:severity sh:Violation ;
-    ];
+  sh:xone (
+      [
+        sh:property [
+          sh:path dct:license ;
+          sh:class dct:LicenseDocument ;
+          sh:minCount 1 ;
+      	  sh:maxCount 1 ;
+        ]
+      ]
+      [
+        sh:property [
+          sh:path dct:rights ;
+          sh:class dct:RightsStatement ;
+	        sh:minCount 1 ;
+      	  sh:maxCount 1 ;
+        ]
+      ]
+  ) ;
   sh:property [
       sh:path dct:language ;
       sh:class dct:LinguisticSystem ;
@@ -295,19 +301,24 @@
       sh:maxCount 1 ;
       sh:severity sh:Violation ;
     ] ;
-  sh:property [
-      sh:path dct:rights ;
-      sh:minCount 1 ;
-      sh:maxCount 1 ;
-      sh:severity sh:Violation ;
-      sh:class dct:RightsStatement ;
-    ] ;
-  sh:property [
-      sh:path dct:license ;
-      sh:maxCount 1 ;
-      sh:severity sh:Violation ;
-      sh:class dct:LicenseDocument ;
-    ] ;
+    sh:xone (
+        [
+          sh:property [
+            sh:path dct:license ;
+            sh:class dct:LicenseDocument ;
+            sh:minCount 1 ;
+        	  sh:maxCount 1 ;
+          ]
+        ]
+        [
+          sh:property [
+            sh:path dct:rights ;
+            sh:class dct:RightsStatement ;
+  	        sh:minCount 1 ;
+        	  sh:maxCount 1 ;
+          ]
+        ]
+    ) ;
   sh:property [
       sh:path dct:identifier ;
       sh:maxCount 1 ;

--- a/ech-0200.shacl.ttl
+++ b/ech-0200.shacl.ttl
@@ -368,10 +368,17 @@
 
 :DateType
   rdf:type sh:NodeShape ;
-  rdfs:comment "Date time date shape checks that a datatype property receives a date literal" ;
+  rdfs:comment "Date time date shape checks that a datatype property receives a date or dateTime literal" ;
   rdfs:label "Date" ;
-  sh:message "The values must be data typed as xsd:date" ;
-  sh:datatype xsd:date
+  sh:message "The values must be data typed as xsd:date or xsd:dateTime." ;
+  sh:or (
+       [
+           sh:datatype xsd:date ;
+       ]
+       [
+           sh:datatype xsd:dateTime ;
+       ]
+   )
 .
 
 :DecimalType

--- a/examples/minimal.valid.ttl
+++ b/examples/minimal.valid.ttl
@@ -12,7 +12,7 @@
     dct:publisher [ a foaf:Agent];
     foaf:homepage <http://example.org/> ;
     dct:title "Catalog"@it;
-    dct:issued "2018-07-12"^^xsd:date;
+    dct:issued "2002-05-30T09:00:00"^^xsd:dateTime;
     dct:rights [ a dct:RightsStatement ] ;
     dcat:themeTaxonomy [ a skos:Concept-Scheme ];
     dcat:dataset [

--- a/examples/minimal.valid.ttl
+++ b/examples/minimal.valid.ttl
@@ -13,7 +13,8 @@
     foaf:homepage <http://example.org/> ;
     dct:title "Catalog"@it;
     dct:issued "2002-05-30T09:00:00"^^xsd:dateTime;
-    dct:rights [ a dct:RightsStatement ] ;
+    dct:license [ a dct:LicenseDocument ] ;
+    
     dcat:themeTaxonomy [ a skos:Concept-Scheme ];
     dcat:dataset [
         a dcat:Dataset;


### PR DESCRIPTION
In this PR we add:
- or `dct:license` or `dct:rights` property.
- Documentation on how to transform `RDF/XML` to `turtle` with `Jena/riot`
- `:DateType` ca be both `xsd:date` and `xsd:dateTime`